### PR TITLE
Fix scheduled workflows

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -15,7 +15,7 @@ jobs:
           distribution: zulu
           java-version: 8
           cache: gradle
-  run-snapshot-tests:   
+  run-snapshot-tests:
     uses: ./.github/workflows/tecton-e2e-test.yml
     with:
       client_version: latest.integration

--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -17,9 +17,9 @@ jobs:
           cache: gradle
   run-snapshot-tests:   
     uses: ./.github/workflows/tecton-e2e-test.yml
-      with:
-        client_version: latest.integration
+    with:
+      client_version: latest.integration
   run-stable-release-tests:
     uses: ./.github/workflows/tecton-e2e-test.yml
-      with:
-        client_version: latest.release
+    with:
+      client_version: latest.release

--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -15,11 +15,11 @@ jobs:
           distribution: zulu
           java-version: 8
           cache: gradle
-      - name: Run Tests for Latest Snapshot 
-        uses: ./.github/workflows/tecton-e2e-test.yml@main
-        with:
-          client_version: latest.integration
-      - name: Run Tests for Latest Public Release
-        uses: ./.github/workflows/tecton-e2e-test.yml@main
-        with:
-          client_version: latest.release
+  run-snapshot-tests:   
+    uses: ./.github/workflows/tecton-e2e-test.yml
+      with:
+        client_version: latest.integration
+  run-stable-release-tests:
+    uses: ./.github/workflows/tecton-e2e-test.yml
+      with:
+        client_version: latest.release


### PR DESCRIPTION
According to GutHub documentation, we cannot call another workflow from the `step` of another job, and can only call it as a separate job