### PR TITLE
Only test latest release version

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -15,17 +15,10 @@ jobs:
           distribution: zulu
           java-version: 8
           cache: gradle
-  run-snapshot-tests:
-    uses: ./.github/workflows/tecton-e2e-test.yml
-    with:
-      client_version: SNAPSHOT
-    secrets:
-      TECTON_URL: ${{ secrets.TECTON_URL }} 
-      TECTON_API_KEY: ${{ secrets.TECTON_API_KEY }}
   run-stable-release-tests:
     uses: ./.github/workflows/tecton-e2e-test.yml
     with:
-      client_version: RELEASE
+      client_version: latest.release
     secrets:
       TECTON_URL: ${{ secrets.TECTON_URL }}
       TECTON_API_KEY: ${{ secrets.TECTON_API_KEY }}

--- a/.github/workflows/tecton-e2e-test.yml
+++ b/.github/workflows/tecton-e2e-test.yml
@@ -17,7 +17,7 @@ on:
       - 'main'
     inputs:
       client_version:
-        description: 'Client Version for Testing, one of SNAPSHOT or RELEASE'
+        description: 'Java Client Version for Testing'
         required: true
 jobs:
   run-e2e-tests:

--- a/build.gradle
+++ b/build.gradle
@@ -11,20 +11,17 @@ version '1.0-SNAPSHOT'
 sourceCompatibility = 8
 targetCompatibility = 8
 
-def client_version = System.getenv('JAVA_CLIENT_VERSION')
+def client_version = System.getenv('JAVA_CLIENT_VERSION') ?: "latest.release"
 
 repositories {
-    if (client_version.equals("RELEASE")) {
         mavenCentral()
-    } else {
         maven {
-            url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+           url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
         }
-    }
 }
 
 dependencies {
-    implementation "ai.tecton:java-client:+"
+    implementation "ai.tecton:java-client:$client_version"
     implementation 'com.google.code.gson:gson:2.2.4'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
Gradle can't download both Snapshot and Public Release as they are hosted in different repositories. For now we run scheduled tests on latest public release but also provide an option to trigger a manual workflow for any release, including SNAPSHOT