### PR TITLE
Add OkHttp Dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,8 @@ repositories {
 }
 
 dependencies {
-    //implementation "ai.tecton:java-client:$client_version"
-    implementation "ai.tecton:java-client:0.5.0-SNAPSHOT"
-    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
+    implementation "ai.tecton:java-client:$client_version"
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'com.google.code.gson:gson:2.2.4'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     testImplementation 'junit:junit:4.13.2'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,9 @@ repositories {
 }
 
 dependencies {
-    implementation "ai.tecton:java-client:$client_version"
+    //implementation "ai.tecton:java-client:$client_version"
+    implementation "ai.tecton:java-client:0.5.0-SNAPSHOT"
+    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
     implementation 'com.google.code.gson:gson:2.2.4'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
In the recent snapshot (0.5.0-SNAPSHOT) the TectonClient takes in an OkHttpClient as a parameter and explicitly depends on OkHttp so we need to add it as a dependency for the demo application