### PR TITLE
Reduce maxParallelRequests for testGetFeaturesBatchE2E_ParallelRequests to 25

### DIFF
--- a/src/test/java/TectonClientE2ETest.java
+++ b/src/test/java/TectonClientE2ETest.java
@@ -71,7 +71,7 @@ public class TectonClientE2ETest {
 
 	@Test
 	public void testGetFeaturesBatchE2E_ParallelRequests() throws IOException {
-		TectonClientOptions clientOptions = new TectonClientOptions.Builder().maxParallelRequests(50).build();
+		TectonClientOptions clientOptions = new TectonClientOptions.Builder().maxParallelRequests(25).build();
 		TectonClient tectonClient = new TectonClient(TECTON_URL, TECTON_API_KEY, clientOptions);
 		List<GetFeaturesRequestData> getFeaturesRequestDataList = GetFeaturesBatchDemo.generateFraudRequestDataFromFile("input.csv");
 		GetFeaturesBatchRequest batchRequest = new GetFeaturesBatchRequest(WORKSPACE_NAME, FEATURE_SERVICE_NAME, getFeaturesRequestDataList, RequestConstants.DEFAULT_METADATA_OPTIONS);


### PR DESCRIPTION
Seeing `ai.tecton.client.exceptions.ResourceExhaustedException: /tecton_proto.api.feature_service.FeatureService/GetFeatures exceeded the concurrent request limit, please retry later.` [occasionally](https://github.com/tecton-ai/tecton-http-client-demo/actions/runs/10479866923/job/29026385925).