### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,6 @@ repositories {
 
 dependencies {
     implementation "ai.tecton:java-client:$client_version"
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
-    implementation 'com.google.code.gson:gson:2.2.4'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     testImplementation 'junit:junit:4.13.2'
 }


### PR DESCRIPTION
With https://github.com/tecton-ai/tecton-http-client-java/pull/85 merged, we no longer need to specify okhttp3 (or gson for that matter) as a dependency. We would still have to include it for locally-built JARs and older versions, but that's addressed by the client library repo's README.